### PR TITLE
chore: improve environment definition and docs on lightning checkpoint loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ $ ./download_ckpts.sh
 This script will download the LMDesign and fine-tuned ProteinMPNN weights associated
 with the split which excluded the [ACVR2B](https://www.ncbi.nlm.nih.gov/gene/93) target.
 
+Version mismatches in the checkpoints from Lightning can be fixed with the following snippet permanently:
+
+```bash
+python -m pytorch_lightning.utilities.upgrade_checkpoint ckpts/igdesign_acvr2b_holdout.ckpt
+python -m pytorch_lightning.utilities.upgrade_checkpoint ckpts/igmpnn_acvr2b_holdout.ckpt
+```
+
 ## Inference
 To inverse fold sequences, run `predict.py` with the environment activated to use the default config with PDB:1N8Z (Trastuzumab-HER2):
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,17 +1,16 @@
 name: igdesign
 channels:
-  - pyg
-  - pytorch
-  - nvidia
-  - bioconda
   - conda-forge
-  - defaults
+  - bioconda
+  - nodefaults
 
 dependencies:
-  - pip
   - python==3.11.9
-  - pytorch::pytorch>=2.0,<2.1
-  - pytorch::pytorch-cuda=11.8
+  - ipython
+  - pip
+  - pytorch>=2.0,<2.1
+  - cuda-version = 12.4
+  - cuda-nvcc
   - pandas>=2.0,<2.1
   - lightning>=2.0,<2.1
   - cytoolz>=0.12.3
@@ -20,8 +19,8 @@ dependencies:
   - biopython>=1.84
   - datasets>=2.20.0
   - hmmer=3.3.2
+  - huggingface_hub>=0.24.5
+  - transformers>=4.42.4
   - anarci
   - pip:
-    - huggingface_hub>=0.24.5
-    - transformers>=4.42.4
     - torchtyping>=0.1.4


### PR DESCRIPTION
This PR contains a simplification of the environment. In addition, I got prompted the following while running the example config, so I added it to the readme as well.

```
Lightning automatically upgraded your loaded checkpoint from v1.6.5 to v2.3.3. To apply the upgrade to your files permanently, run `python -m pytorch_lightning.utilities.upgrade_checkpoint ckpts/igdesign_acvr2b_holdout.ckpt`
Seed set to 42
Lightning automatically upgraded your loaded checkpoint from v1.6.5 to v2.3.3. To apply the upgrade to your files permanently, run `python -m pytorch_lightning.utilities.upgrade_checkpoint ckpts/igmpnn_acvr2b_holdout.ckpt`
Seed set to 17
```

HTH
Cheers,
